### PR TITLE
Bug fixes

### DIFF
--- a/lib/channelVideosPage.dart
+++ b/lib/channelVideosPage.dart
@@ -39,6 +39,7 @@ class _ChannelVideosPageState extends State<ChannelVideosPage> {
     final scrapedVideos = await fetchVideosFromChannel(widget.videoId);
     setState(() {
       channelVideos = scrapedVideos
+          .where((v) => v.title != null && v.title!.isNotEmpty)
           .map((v) => MyVideo(
                 videoId: v.videoId,
                 duration: v.duration,

--- a/lib/channelVideosPage.dart
+++ b/lib/channelVideosPage.dart
@@ -1,4 +1,6 @@
 import 'package:audiobinge/bottomPlayer.dart';
+import 'package:audiobinge/downloadsPage.dart';
+import 'package:audiobinge/favoritePage.dart';
 import 'package:audiobinge/main.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
@@ -19,6 +21,9 @@ class ChannelVideosPage extends StatefulWidget {
 class _ChannelVideosPageState extends State<ChannelVideosPage> {
   List<MyVideo> channelVideos = [];
   bool _isLoading = true; // Loading state
+  int _selectedIndex = 0;
+  List<Widget> get _pages =>
+      [channelVideoScreen(), FavoriteScreen(), DownloadScreen()];
 
   @override
   void initState() {
@@ -48,6 +53,32 @@ class _ChannelVideosPageState extends State<ChannelVideosPage> {
     });
   }
 
+  void _onItemTapped(int index) {
+    setState(() {
+      _selectedIndex = index;
+    });
+  }
+
+  Widget channelVideoScreen() {
+    return (_isLoading
+        ? Center(child: CircularProgressIndicator(color: Colors.red))
+        : channelVideos.isEmpty
+            ? Center(
+                child: Text('No videos found.',
+                    style: TextStyle(fontSize: 20, color: Colors.white)))
+            : GridView.builder(
+                gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                  crossAxisCount: 2,
+                  crossAxisSpacing: 10.0,
+                  mainAxisSpacing: 20.0,
+                ),
+                itemCount: channelVideos.length,
+                itemBuilder: (context, index) {
+                  return VideoComponent(video: channelVideos[index]);
+                },
+              ));
+  }
+
   @override
   Widget build(BuildContext context) {
     final playing = context.watch<Playing>();
@@ -55,32 +86,44 @@ class _ChannelVideosPageState extends State<ChannelVideosPage> {
       appBar: AppBar(title: Text('${widget.channelName} Videos')),
       body: Stack(
         children: [
-          _isLoading
-              ? Center(child: CircularProgressIndicator(color: Colors.red))
-              : channelVideos.isEmpty
-                  ? Center(
-                      child: Text('No videos found.',
-                          style: TextStyle(fontSize: 20, color: Colors.white)))
-                  : GridView.builder(
-                      gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-                        crossAxisCount: 2,
-                        crossAxisSpacing: 10.0,
-                        mainAxisSpacing: 20.0,
-                      ),
-                      itemCount: channelVideos.length,
-                      itemBuilder: (context, index) {
-                        return VideoComponent(video: channelVideos[index]);
-                      },
-                    ),
+          AnimatedSwitcher(
+            duration: Duration(milliseconds: 300),
+            child: _pages[_selectedIndex],
+            transitionBuilder: (Widget child, Animation<double> animation) {
+              return FadeTransition(
+                opacity: animation,
+                child: child,
+              );
+            },
+          ),
           // BottomPlayer overlay
           if (playing.video.title != null && playing.isPlayerVisible)
             Positioned(
               left: 0,
               right: 0,
-              bottom: 0,
+              bottom:
+                  kBottomNavigationBarHeight, // adjust to sit above the nav bar
               child: BottomPlayer(),
             ),
         ],
+      ),
+      bottomNavigationBar: BottomNavigationBar(
+        currentIndex: 0, // adjust if needed
+        items: const [
+          BottomNavigationBarItem(
+            icon: Icon(Icons.video_library),
+            label: 'Channel',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.favorite_sharp),
+            label: 'Favorites',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.download_for_offline_rounded),
+            label: 'Downloads',
+          ),
+        ],
+        onTap: _onItemTapped,
       ),
     );
   }


### PR DESCRIPTION
- fixed the bug of the last video in the channel being Null
- added the bottom navigation to the channel videos page

This pull request makes several significant updates to the `ChannelVideosPage` in the `lib/channelVideosPage.dart` file, enhancing its functionality and user interface. The most important changes include adding new imports for the favorites and downloads pages, introducing a bottom navigation bar, and refining the video fetching logic.

### Enhancements to user interface and functionality:

* Added imports for `downloadsPage.dart` and `favoritePage.dart` to support new navigation features.
* Introduced a bottom navigation bar with three tabs: Channel, Favorites, and Downloads. This allows users to switch between different pages within the `ChannelVideosPage`.
* Implemented a method to handle navigation item taps (`_onItemTapped`) and updated the state to reflect the selected tab.
* Added an `AnimatedSwitcher` to smoothly transition between different pages when the user navigates using the bottom navigation bar.

### Code improvements:

* Refined the video fetching logic to filter out videos with null or empty titles, ensuring only valid videos are displayed.